### PR TITLE
Code: Fixed a small problem while calling function win().

### DIFF
--- a/sources/uno.move
+++ b/sources/uno.move
@@ -213,7 +213,7 @@ module local::uno {
 
         if(vector::length(&cards_in_deck) == 1) { shout_UNO(deck); };
 
-        if(vector::length(&cards_in_deck) == 0) { game_objects::win(/*game, */cards_in_deck, ctx); }
+        if(vector::length(&cards_in_deck) == 0) { game_objects::win(/*game, */ctx); }
         else {
             game_objects::update_state(deck, false);
 


### PR DESCRIPTION
Function *win()* in uno.move only need **ctx** argument. It had two arments though. The extra one was deleted.